### PR TITLE
Adjust nginx config for polylan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ bower.json
 # Ignore node_modules
 node_modules/
 
+.rakeTasks
+.generators
+.idea

--- a/webapp.conf
+++ b/webapp.conf
@@ -3,21 +3,38 @@ server {
     listen 80;
 	
     server_name _;
-	
-    root /home/app/webapp/public;
-	
-    passenger_enabled on;
-    passenger_user app;
-	
-    # For Ruby 2.6
-    passenger_ruby /usr/bin/ruby2.6;
-	
+
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 10.233.200.1;
+    set_real_ip_from 10.233.200.2;
+
 	ssl_certificate /etc/ssl/certificates/local_login_cert.pem;
 	ssl_certificate_key /etc/ssl/certificates/local_login_key.pem;
-	
-	location /.well-known/ {
-		alias /var/www/letsencrypt/;
+
+	location / {
+	    return 301 https://pfsense.lan.geco.ethz.ch$request_uri;
 	}
-	
+}
+
+server {
+	listen 443 ssl;
+
+    server_name pfsense.lan.geco.ethz.ch;
+
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 10.233.200.1;
+    set_real_ip_from 10.233.200.2;
+
+    root /home/app/webapp/public;
+
+    passenger_enabled on;
+    passenger_user app;
+
+    # For Ruby 2.6
+    passenger_ruby /usr/bin/ruby2.6;
+
+	ssl_certificate /etc/ssl/certificates/local_login_cert.pem;
+	ssl_certificate_key /etc/ssl/certificates/local_login_key.pem;
+
 	client_max_body_size 15M;
 }


### PR DESCRIPTION
This makes it redirect all random requests to the correct host (required
for captive portal mode) and also read out the real client IP.